### PR TITLE
Use string operator in test

### DIFF
--- a/git/git-rebasetosubtree.sh
+++ b/git/git-rebasetosubtree.sh
@@ -29,7 +29,7 @@ else
 fi
 
 # check we are on the right branch
-if [[ `git rev-parse --abbrev-ref HEAD` -eq "$NEWBRANCH" ]]
+if [[ `git rev-parse --abbrev-ref HEAD` == "$NEWBRANCH" ]]
 then
     # --all
     git filter-branch -f --prune-empty --subdirectory-filter $DIR HEAD -- && git gc --aggressive --prune=now


### PR DESCRIPTION
If a branch name contains dot chars (e.g. "foo.1.1") use of the '-eq' arithmetic comparison operator will fail with a message like:
bash: [[: foo.1.1: syntax error: invalid arithmetic operator (error token is ".1.1")

The string operator '==' operator should be used instead.